### PR TITLE
Revert "FS-10191: don't send "video-floor-change" event for audio-only conference"

### DIFF
--- a/src/mod/applications/mod_conference/conference_loop.c
+++ b/src/mod/applications/mod_conference/conference_loop.c
@@ -1193,7 +1193,7 @@ void *SWITCH_THREAD_FUNC conference_loop_input(switch_thread_t *thread, void *ob
 
 			member->last_score = member->score;
 
-			if ((switch_channel_test_flag(channel, CF_VIDEO) || member->avatar_png_img) && (member->id == member->conference->floor_holder)) {
+			if (member->id == member->conference->floor_holder) {
 				if (member->id != member->conference->video_floor_holder &&
 					(member->floor_packets > member->conference->video_floor_packets || member->energy_level == 0)) {
 					conference_video_set_floor_holder(member->conference, member, SWITCH_FALSE);


### PR DESCRIPTION
This reverts commit 4d4afbeb5d9a6aa2d8fced093aeba9b27c1e5623.

Closes https://github.com/mconf/mconf-tracker/issues/175

I'll make the behaviour that commit introduced configurable soon:tm: and send a patch to upstream FreeSWITCH.